### PR TITLE
Adds test_no_errors unittest

### DIFF
--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -22,6 +22,22 @@ class TestProcessingFunctions(unittest.TestCase):
         self.assertEqual(process_error(None), None)
         self.assertEqual(process_error(""), None)
 
+
+    def test_no_errors(self):
+        """ Asserts format_errors function returns None when
+        
+
+        """
+        test_error = "\r\n--------------------------------------------------------------------\r\n"\
+        "Your code has been rated at 10.00/10 (previous run: 9.33/10, +0.67)"
+
+        self.assertEqual(
+            format_errors(test_error),
+            None
+        )
+
+
+
 if __name__ == '__main__':
     # print(process_error("s"))
     unittest.main()


### PR DESCRIPTION
Adds unit test  to cover missing case by coverage(format_errors input is pylint success message `code rated at...` )
Travis CI build: https://travis-ci.org/chaps/PythonBuddy/builds/595419922

Covers/tests line `175` , coverage report before and after the test case was added:

```
coverage report -m
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
PythonBuddy/__init__.py                          0      0   100%
PythonBuddy/app.py                             118     48    59%   23, 42-44, 66-71, 85-95, 99-103, 123-146, 175, 186-189, 247, 297, 302
PythonBuddy/pylint_errors/__init__.py            1      0   100%
PythonBuddy/pylint_errors/pylint_errors.py       2      0   100%
--------------------------------------------------------------------------
TOTAL                                          121     48    60%
```

```
coverage report -m
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
PythonBuddy/__init__.py                          0      0   100%
PythonBuddy/app.py                             118     46    61%   23, 42-44, 66-71, 85-95, 99-103, 123-146, 186-189, 297, 302
PythonBuddy/pylint_errors/__init__.py            1      0   100%
PythonBuddy/pylint_errors/pylint_errors.py       2      0   100%
--------------------------------------------------------------------------
TOTAL                                          121     46    62%
```