### PR TITLE
Adds flask unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 install: "pip install -r requirements.txt"
 # command to run tests
 script:
-  - python -m unittests tests/test_linter.py tests/test_flask.py
+  - python -m unittest tests/test_linter.py tests/test_flask.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 install: "pip install -r requirements.txt"
 # command to run tests
 script:
-  - python -m tests.test_linter
+  - python -m unittests tests/test_linter.py tests/test_flask.py

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,0 +1,63 @@
+import os
+import unittest
+import tempfile
+from PythonBuddy.app import app
+
+class FlaskrTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.db_fd, app.config['DATABASE'] = tempfile.mkstemp()
+        app.testing = True
+        self.app = app.test_client()
+        with app.app_context():
+            pass
+
+    def tearDown(self):
+        os.close(self.db_fd)
+        os.unlink(app.config['DATABASE'])
+
+
+    def test_index(self):
+        """ Tests a request to index returns a 200 status code.
+        """
+        result = self.app.get('/')    
+        self.assertEqual(result.status_code, 200)
+
+
+    def test_check_code(self):
+        """  
+        Tests the /check_code endpoint can handle an empty payload.
+        """ 
+        response = self.app.post("/check_code")
+        self.assertEqual(result.status_code, 200)
+
+
+    def test_check_code(self):
+        """ Tests the response json object
+        from /check_code returns the documented JSON object.
+        """
+        response = self.app.post("/check_code", data={"text": "TEST_INPUT"})
+        self.assertIsInstance(response.json, dict)
+
+    def test_run_code_index_setup_no_check_code(self):
+        """ Tests making a request
+        directly to /run_code after hitting
+        / but not /check_code does not raise Index errors
+        due to session keys not being set.
+        """
+        response = self.app.get("/")
+        response = self.app.post("/run_code")
+        self.assertIsInstance(response.json,dict)
+
+    def test_run_code_no_index_setup(self):
+        """ Tests making a request
+        directly to /run_code before hitting
+        /index does not raise Index errors
+        due to session keys not being set.
+        """
+        response = self.app.post("/run_code")
+        self.assertIsInstance(response.json,dict)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds some test cases for requests on different endpoints.
- If endpoints are not requested in a particular order, some session variables are not being set.
- `test_check_code` states that it returns a JSON object when it currently returns a list of values that contains the expected JSON object as the first element.

These test cases can serve in order to add coverage for the use cases and maybe open them as issues: 
- initialize the session dict key values if not set,  in order to avoid these KeyErrors raised exceptions.
- make sure `check_code` returns the documented value
