### PR TITLE
Adds support for coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: python
 python:
   - "3.6"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: 
+  - "pip install -r requirements.txt"
+  - pip install coverage
+  - pip install coveralls
 # command to run tests
 script:
-  - python -m tests.test_linter
+  - coverage run --source=PythonBuddy -m unittest tests/test_linter.py
+  - coverage report -m 
+  - coveralls


### PR DESCRIPTION
Adds setup in `.travis.yml` to run coverage in travis and report coverage to coveralls.io

Generated artifacts:
https://travis-ci.org/chaps/PythonBuddy/builds/595634318
https://coveralls.io/github/chaps/PythonBuddy