### PR TITLE
Fix Codemirror Python Version

### DIFF
--- a/PythonBuddy/static/js/javascript.js
+++ b/PythonBuddy/static/js/javascript.js
@@ -100,7 +100,7 @@ $(document).ready(function() {
   var editor = CodeMirror.fromTextArea(document.getElementById("txt"), {
     mode: {
       name: "python",
-      version: 2,
+      version: 3,
       singleLineStringErrors: false
     },
     lineNumbers: true,


### PR DESCRIPTION
As a user, I want to be shown syntax highlighting for Python 3 instead of Python 2.