### PR TITLE
docs: Fix simple typo, vitrual -> virtual

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Online Python 3.6 Programming with Live Pylint Syntax Checking!
   ```
   python3 -m venv venv
   ```
-3) Activate vitrual environment:
+3) Activate virtual environment:
   ```
   source venv/bin/activate
   ```


### PR DESCRIPTION
There is a small typo in README.md.

Should read `virtual` rather than `vitrual`.

